### PR TITLE
GitHub Actions CI を設定

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: ["3.9", "3.13"]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+      - name: Install dependencies
+        run: uv sync --all-extras
+      - name: Run tests
+        run: uv run pytest


### PR DESCRIPTION
## Summary

- GitHub Actions CI ワークフローを追加（`.github/workflows/ci.yml`）
- OS（ubuntu / windows / macos）× Python（3.9 / 3.13）のマトリクスで pytest を実行
- push・PR 時に自動でテストが走る

closes #11

## Test plan

- [ ] CI が全マトリクス（6パターン）で green になること
- [ ] 既存テスト（5ファイル）がすべてパスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)